### PR TITLE
Add upper bound to reflex-dom dependency

### DIFF
--- a/reflex-dom-helpers.cabal
+++ b/reflex-dom-helpers.cabal
@@ -26,7 +26,7 @@ library
   build-depends:
       base >= 4.7 && < 5
     , reflex
-    , reflex-dom
+    , reflex-dom < 0.4
     , template-haskell
   default-language:    Haskell2010
   default-extensions:


### PR DESCRIPTION
The library *reflex-dom-helpers*  doesn't compile with reflex-dom 0.4! For performance reflex-dom 0.4 switched all String type function parameters to Data.Text 
reflex-dom 0.4 is currently on Github, but it will probably be uploaded to Hackage in the near future.