### PR TITLE
Make reflex-dom-helpers ready for reflex-dom 0 4

### DIFF
--- a/reflex-dom-helpers.cabal
+++ b/reflex-dom-helpers.cabal
@@ -1,5 +1,5 @@
 name:                reflex-dom-helpers
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            Element tag helpers for working with reflex-dom
 description:         Please see README.md
 homepage:            https://github.com/layer-3-communications/reflex-dom-helpers
@@ -26,10 +26,12 @@ library
   build-depends:
       base >= 4.7 && < 5
     , reflex
-    , reflex-dom
+    , reflex-dom >= 0.4 && < 0.5
     , template-haskell
+    , text == 1.2.*
   default-language:    Haskell2010
   default-extensions:
+      OverloadedStrings
       TemplateHaskell
       NoMonomorphismRestriction
 

--- a/src/Reflex/Tags/TH.hs
+++ b/src/Reflex/Tags/TH.hs
@@ -16,11 +16,12 @@ module Reflex.Tags.TH where
 
 import Reflex.Dom.Widget
 import Control.Monad
+import qualified Data.Text as T
 
 import Language.Haskell.TH
 
 -- | A list of all HTML elements.
-elements :: [String]
+elements :: [T.Text]
 elements =
   [ "a"
   , "abbr"
@@ -148,11 +149,11 @@ elements =
 -- | Given a name for a function and a suffix, this function will generate
 -- a list of declarations. Each declaration will consist of the function applied
 -- to each of the HTML elements with the given suffix.
-gen :: Name -> String -> DecsQ
+gen :: Name -> T.Text -> DecsQ
 gen sym suffix =
     forM elements $ \element -> do
-        let name = mkName (element ++ suffix)
-        funD name [clause [] (normalB (appE (varE sym) (stringE element))) []]
+        let name = mkName (T.unpack element ++ T.unpack suffix)
+        funD name [clause [] (normalB (appE (varE sym) (stringE (T.unpack element)))) []]
 
 -- | Generate 'el' functions for all of the elements with an @_@ suffix.
 gen_ :: DecsQ

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,14 +2,26 @@ flags: {}
 extra-package-dbs: []
 packages:
 - '.'
+- location:
+    git: https://github.com/reflex-frp/reflex
+    commit: 91299fce0bb2caddfba35af6608df57dd31e3690
+- location:
+    git: https://github.com/reflex-frp/reflex-dom
+    commit: 66b6d35773fcb337ab38ebce02c4b23baeae721e
+
 extra-deps:
-- cpphs-1.20.1
-- ghcjs-dom-0.2.3.1
-- haskell-src-exts-1.16.0.1
-- ref-tf-0.4
-- reflex-0.4.0
-- reflex-dom-0.3
-- syb-0.5.1
-- webkitgtk3-0.14.1.1
-- webkitgtk3-javascriptcore-0.13.1.2
-resolver: lts-5.13
+- prim-uniq-0.1.0.1
+- ref-tf-0.4.0.1
+- zenc-0.1.1
+
+resolver: lts-6.25
+compiler: ghcjs-0.2.0.9006025_ghc-7.10.3
+compiler-check: match-exact
+
+setup-info:
+  ghcjs:
+    source:
+      ghcjs-0.2.0.9006025_ghc-7.10.3:
+         url: http://ghcjs.tolysz.org/lts-6.25-9006025.tar.gz
+         sha1: 3c87228579b55c05e227a7876682c2a7d4c9c007
+


### PR DESCRIPTION
This PR allows successful compilation of *reflex-dom-helpers* with the current new version 0.4 of *reflex-dom*, currently only in the Github repository.
The library *reflex-dom* changed all function parameters of type String to type Data.Text.

This is a code breaking change, therefore I bumped the version number in the cabal file.

**Notes to the changes in the *stack.yaml*  file:**
The new versions of *reflex* and *reflex-dom* are not yet on Hackage. Therefore they are referred to as links to the Github repo. After these 2 packages are released to Hackage, the yaml file should be changed accordingly. I use the library with the ghcjs compiler to create Web pages. Hence the other changes to the yaml file.